### PR TITLE
fix centos6 box source

### DIFF
--- a/boxes.json
+++ b/boxes.json
@@ -41,7 +41,7 @@
   },
   "centos6": {
     "provider": "virtualbox",
-    "box": "chef/centos-6.7",
+    "box": "bento/centos-6.7",
     "platform": "centos",
     "platform_version": "6"
   },


### PR DESCRIPTION
for some reason centos6 box from 'chef ' does not work; working box is present in 'bento'
