### PR TITLE
Configure timezone in MaxScale cookbook

### DIFF
--- a/recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
+++ b/recipes/cookbooks/mariadb-maxscale/recipes/install_maxscale.rb
@@ -92,6 +92,14 @@ case node[:platform_family]
     end
 end # save iptables rules
 
+# Set timezone to Europe/Paris
+case node[:platform_family]
+when "debian", "ubuntu", "rhel", "fedora", "centos", "suse", "opensuse"
+  execute "Set timezone to Europe/Paris" do
+    command "rm -f /etc/localtime && ln -s /usr/share/Europe/Paris /etc/localtime"
+  end
+end # iptables rules
+
 # Install packages
 case node[:platform_family]
 when "suse"


### PR DESCRIPTION
The MaxScale cookbook now sets the timezone to Europe/Paris. This keeps
the timezones consistent and makes reading of the logs easier.
