### PR TITLE
Generate correct CTest -I arguments

### DIFF
--- a/confs/libvirt.json
+++ b/confs/libvirt.json
@@ -2,8 +2,8 @@
   "cookbook_path" : "../recipes/cookbooks/",
   "node_000" :
   {
-    "hostname" : "node_000",
-    "box" : "debian_wheezy_libvirt",
+    "hostname" : "node-000",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "mariadb",
@@ -16,8 +16,8 @@
 
   "node_001" :
   {
-    "hostname" : "node_001",
-    "box" : "debian_jessie_libvirt",
+    "hostname" : "node-001",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "mariadb",
@@ -29,8 +29,8 @@
 
   "node_002" :
   {
-    "hostname" : "node_002",
-    "box" : "ubuntu_trusty_libvirt",
+    "hostname" : "node-002",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "mariadb",
@@ -42,8 +42,8 @@
 
   "node_003" :
   {
-    "hostname" : "node_003",
-    "box" : "ubuntu_xenial_libvirt",
+    "hostname" : "node-003",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "mariadb",
@@ -55,7 +55,7 @@
 
   "galera_000" :
   {
-    "hostname" : "galera_000",
+    "hostname" : "galera-000",
     "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
@@ -68,8 +68,8 @@
 
   "galera_001" :
   {
-    "hostname" : "galera_001",
-    "box" : "centos_6_libvirt",
+    "hostname" : "galera-001",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "galera",
@@ -81,8 +81,8 @@
 
   "galera_002" :
   {
-    "hostname" : "galera_002",
-    "box" : "ubuntu_trusty_libvirt",
+    "hostname" : "galera-002",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "galera",
@@ -94,8 +94,8 @@
 
   "galera_003" :
   {
-    "hostname" : "galera_003",
-    "box" : "ubuntu_trusty_libvirt",
+    "hostname" : "galera-003",
+    "box" : "centos_7_libvirt",
     "memory_size" : "1024",
     "product" : {
       "name": "galera",
@@ -108,7 +108,7 @@
   "maxscale" :
   {
     "hostname" : "maxscale",
-    "box" : "ubuntu_trusty_libvirt",
+    "box" : "centos_7_libvirt",
     "product" : {
       "name" : "maxscale"
     },

--- a/repo.d/maxscale/centos-5.json
+++ b/repo.d/maxscale/centos-5.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":		"default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//centos/5/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/centos/5/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"centos",
    "platform_version":	"5"

--- a/repo.d/maxscale/centos-6.json
+++ b/repo.d/maxscale/centos-6.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":		"default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//centos/6/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/centos/6/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"centos",
    "platform_version":	"6"

--- a/repo.d/maxscale/centos-7.json
+++ b/repo.d/maxscale/centos-7.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":		"default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//centos/7/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/centos/7/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"centos",
    "platform_version":	"7"

--- a/repo.d/maxscale/debian-jessie.json
+++ b/repo.d/maxscale/debian-jessie.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//debian jessie main ",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/debian jessie main ",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"debian",
    "platform_version":  "jessie"

--- a/repo.d/maxscale/debian-sqeeze.json
+++ b/repo.d/maxscale/debian-sqeeze.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//debian sqeeze main ",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/debian sqeeze main ",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"debian",
    "platform_version":  "sqeeze"

--- a/repo.d/maxscale/debian-wheezy.json
+++ b/repo.d/maxscale/debian-wheezy.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//debian wheezy main ",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/debian wheezy main ",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"debian",
    "platform_version":  "wheezy"

--- a/repo.d/maxscale/opensuse-13.json
+++ b/repo.d/maxscale/opensuse-13.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//opensuse/13/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/opensuse/13/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"opensuse",
    "platform_version":  "13"

--- a/repo.d/maxscale/rhel-5.json
+++ b/repo.d/maxscale/rhel-5.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//rhel/5/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/rhel/5/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"rhel",
    "platform_version":  "5"

--- a/repo.d/maxscale/rhel-6.json
+++ b/repo.d/maxscale/rhel-6.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//rhel/6/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/rhel/6/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"rhel",
    "platform_version":  "6"

--- a/repo.d/maxscale/rhel-7.json
+++ b/repo.d/maxscale/rhel-7.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//rhel/7/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/rhel/7/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"rhel",
    "platform_version":  "7"

--- a/repo.d/maxscale/sles-11.json
+++ b/repo.d/maxscale/sles-11.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//sles/11/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/sles/11/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"sles",
    "platform_version":  "11"

--- a/repo.d/maxscale/sles-12.json
+++ b/repo.d/maxscale/sles-12.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//sles/12/$basearch",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/sles/12/$basearch",
    "repo_key":		"http://maxscale-jenkins.mariadb.com/repository/release/mariadb-maxscale/Maxscale-GPG-KEY.public",
    "platform":		"sles",
    "platform_version":  "12"

--- a/repo.d/maxscale/ubuntu-precise.json
+++ b/repo.d/maxscale/ubuntu-precise.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//ubuntu precise main",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/ubuntu precise main",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"ubuntu",
    "platform_version":  "precise"

--- a/repo.d/maxscale/ubuntu-trusty.json
+++ b/repo.d/maxscale/ubuntu-trusty.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//ubuntu trusty main",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/ubuntu trusty main",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"ubuntu",
    "platform_version":  "trusty"

--- a/repo.d/maxscale/ubuntu-utopic.json
+++ b/repo.d/maxscale/ubuntu-utopic.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//ubuntu utopic main",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/ubuntu utopic main",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"ubuntu",
    "platform_version":  "utopic"

--- a/repo.d/maxscale/ubuntu-vivid.json
+++ b/repo.d/maxscale/ubuntu-vivid.json
@@ -2,7 +2,7 @@
 {
    "product":		"maxscale",
    "version":           "default",
-   "repo":		"http://maxscale-jenkins.mariadb.com/ci-repository/develop/mariadb-maxscale//ubuntu trusty main",
+   "repo":		"http://max-tst-01.mariadb.com/ci-repository/develop/mariadb-maxscale/ubuntu trusty main",
    "repo_key":		"70E4618A8167EE24",
    "platform":		"ubuntu",
    "platform_version":  "vivid"

--- a/scripts/build_parser/parse_ctest_log.rb
+++ b/scripts/build_parser/parse_ctest_log.rb
@@ -264,7 +264,7 @@ class CTestParser
     sorted_test_indexes_array.each do |test_index|
       if test_index == sorted_test_indexes_array[0]
         ctest_arguments.push(test_index, test_index)
-        ctest_arguments.push(' ') if sorted_test_indexes_array.size > 1
+        ctest_arguments.push('1') if sorted_test_indexes_array.size > 1
       else
         ctest_arguments.push(test_index)
       end


### PR DESCRIPTION
The follwing syntax is for the -I argument for CTest.

    -I [Start,End,Stride,test#,test#]

The correct way is to inject a '1' instead of a space for the value of
Stride.